### PR TITLE
Update static links

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <div><a href="transferor_stuckor">Staging workflows</a> - workflows in "staging" status</div>
       <div><a href="main_bkg_ul">Main background UL</a> - CMS Main Monte Carlo Background Samples for UL</div>
       <div style="margin-top: 20px;">
-        <a href="https://github.com/cms-PdmV/PdmVPages">GitHub</a> | <i><a href="https://cms-pdmv.cern.ch/">Go to PdmV homepage</a></i>
+        <a href="https://github.com/cms-PdmV/PdmVPages">GitHub</a> | <i><a href="https://cms-pdmv-prod.web.cern.ch/">Go to PdmV homepage</a></i>
       </div>
     </div>
   </body>

--- a/main_bkg_ul/index.html
+++ b/main_bkg_ul/index.html
@@ -115,7 +115,7 @@
   <body>
     <div id="app">
       <div class="logo">
-        <a href="https://cms-pdmv.cern.ch/home/" target="_blank"> <img src="logo_cropped.png" style="width: 200px;"> </a>
+        <a href="https://cms-pdmv-prod.web.cern.ch/home/" target="_blank"> <img src="logo_cropped.png" style="width: 200px;"> </a>
       </div>
       <h3 style="text-align: center;">CMS Main Monte Carlo Background Samples - UL</h3>
       <small style="text-align: center; margin-top: -12px; display: block"><i>proudly made by Jordan Martins</i></small>
@@ -473,10 +473,10 @@
             return result
           },
           makeMcMLink(prepid) {
-            return 'https://cms-pdmv.cern.ch/mcm/requests?prepid=' + prepid;
+            return 'https://cms-pdmv-prod.web.cern.ch/mcm/requests?prepid=' + prepid;
           },
           makeStats2Link(prepid) {
-            return 'https://cms-pdmv.cern.ch/stats/?request=' + prepid;
+            return 'https://cms-pdmv-prod.web.cern.ch/stats/?request=' + prepid;
           },
           makeTransferorLink(workflow_name) {
             return 'https://pdmv-pages.web.cern.ch/transferor_stuckor/?workflow=' + workflow_name;

--- a/transferor_stuckor/index.html
+++ b/transferor_stuckor/index.html
@@ -349,7 +349,7 @@
             return Math.round(seconds) + 's'
           },
           makeStatsLink(workflow) {
-            return 'https://cms-pdmv.cern.ch/stats?workflow_name=' + workflow;
+            return 'https://cms-pdmv-prod.web.cern.ch/stats/?workflow_name=' + workflow;
           },
           makeDASSiteLink(dataset) {
             return 'https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=site+dataset%3D' + dataset;


### PR DESCRIPTION
1. Use the new domain `cms-pdmv-prod.web.cern.ch` for the static href tags