### PR TITLE
Bugfix: Do not overwrite the dataset version for `custom` datasets.

### DIFF
--- a/run_3_data/schemas/dataset.py
+++ b/run_3_data/schemas/dataset.py
@@ -52,6 +52,12 @@ class DatasetMetadata:
             - /BTagMu/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD
                 processing_string := PromptNanoAODv11_v1
                 filtered_ps := PromptNanoAODv11
+        filtered_version (str): Similar to the case described above,
+            this field stores the 'original' dataset version the current
+            customizes, it is only stored just as a reference. For example:
+            - /BTagMu/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD
+                version := v2
+                filtered_version := v1
         version (str): Dataset's version, e.g: v4
         datatier (str): Dataset's data tier, e.g: AOD
         valid (bool): Determines if the dataset is valid using a predefined regex.
@@ -69,6 +75,7 @@ class DatasetMetadata:
         self.era: str = ""
         self.processing_string: str = ""
         self.filtered_ps: str = ""
+        self.filtered_version: str = ""
         self.version: str = ""
         self.datatier: str = ""
         self.__valid: bool = False
@@ -127,7 +134,7 @@ class DatasetMetadata:
     def __check_ps(self) -> None:
         """
         Check the processing string to determine
-        if there is a version tag that overwrites the
+        if there is a version tag that customizes the
         current one.
         """
         components: List[str] = DatasetMetadata.SUBVERSION.findall(self.processing_string)
@@ -137,7 +144,7 @@ class DatasetMetadata:
         # Parse the fields
         filtered_ps, version = components[0]
         self.filtered_ps = filtered_ps
-        self.version = version
+        self.filtered_version = version
 
     @property
     def valid(self) -> bool:
@@ -213,11 +220,25 @@ class ChildDataset:
             "workflow": self.workflow,
             "output": child_dataset,
         }
+    
+    def _children_names(self) -> str:
+        """
+        Retrieves all the dataset names related to
+        the children the current dataset has.
+        """
+        if not self.output:
+            return ""
+        
+        return pprint.pformat(
+            [e.metadata.full_name for e in self.output],
+            indent=4,
+            compact=True
+        )
 
     def __repr__(self) -> str:
         repr: str = (
             f"<ChildDataset full_name={self.metadata.full_name} "
-            f"children={len(self.output)} output_id={id(self.output)}>"
+            f"children({len(self.output)})={self._children_names()} output_id={id(self.output)}>"
         )
         return repr
 

--- a/run_3_data/utils/das.py
+++ b/run_3_data/utils/das.py
@@ -5,6 +5,7 @@ DAS CLI client
 import json
 import os
 import logging
+import pprint
 from typing import List, Tuple, Optional, Dict
 from schemas.dataset import DatasetMetadata, ChildDataset
 
@@ -139,6 +140,8 @@ def group_as_child_dataset(children: List[DatasetMetadata]) -> List[ChildDataset
         group_key = (child.processing_string, child.version)
         groups[group_key] = groups.get(group_key, []) + [child]
 
+    logger.debug("Child dataset groups: %s", pprint.pformat(groups, indent=4, compact=True))
+
     # Key: (processing_str, version)
     reduced_children: Dict[Tuple[str, str], ChildDataset] = {}
 
@@ -164,6 +167,7 @@ def group_as_child_dataset(children: List[DatasetMetadata]) -> List[ChildDataset
         reduced_children[key] = parent
 
     children: List[ChildDataset] = list(reduced_children.values())
+    logger.debug("Child dataset result: %s", pprint.pformat(children, indent=4, compact=True))
     return children
 
 


### PR DESCRIPTION
Consider the following dataset name: /BtagMu/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD. This name suggests there are two possible versions, v1 and v2. Before this update, the main version taken was the one included in the processing string. However, the last raises issues for the grouping operation. So:

1. Store the version in the processing string just as a reference instead of overwriting the `version` attribute.

Also:

2. Include some debug functions to check how the relationship is built.